### PR TITLE
cmd/gc: support checknil on non-reg operands on arm64

### DIFF
--- a/src/cmd/gc/pgen.c
+++ b/src/cmd/gc/pgen.c
@@ -528,7 +528,7 @@ cgen_checknil(Node *n)
 		dump("checknil", n);
 		fatal("bad checknil");
 	}
-	if(((thechar == '5' || thechar == '9') && n->op != OREGISTER) || !n->addable || n->op == OLITERAL) {
+	if(((thechar == '5' || thechar == '7' || thechar == '9') && n->op != OREGISTER) || !n->addable || n->op == OLITERAL) {
 		regalloc(&reg, types[tptr], n);
 		cgen(n, &reg);
 		gins(ACHECKNIL, &reg, N);


### PR DESCRIPTION
This feels like I am continuing the perpetration of a hack but oh well.
