### PR TITLE
liblink: add DRconv printing

### DIFF
--- a/include/link.h
+++ b/include/link.h
@@ -632,6 +632,7 @@ extern	char*	anames8[];
 extern	char*	anames9[];
 
 extern	char*	cnames5[];
+extern	char*	cnames7[];
 extern	char*	cnames9[];
 
 extern	char*	dnames5[];

--- a/src/liblink/asm7.c
+++ b/src/liblink/asm7.c
@@ -1098,7 +1098,8 @@ oplook(Link *ctxt, Prog *p)
 					p->optab = ((o - optab)) + 1;
 					return o;
 				}
-	ctxt->diag("illegal combination %A %R %R %R", p->as, a1, a2, a3);
+	ctxt->diag("illegal combination %P %^ %^ %^, %d %d",
+                p, a1, a2, a3, p->from.type, p->to.type);
 	prasm(p);
 	o = badop;
 	if(o == 0)

--- a/src/liblink/list7.c
+++ b/src/liblink/list7.c
@@ -17,6 +17,7 @@ static int Dconv(Fmt*);
 static int Mconv(Fmt*);
 static int Rconv(Fmt*);
 static int DSconv(Fmt*);
+static int DRconv(Fmt*);
 
 static char *strcond[16] = {
 	"EQ",
@@ -49,6 +50,7 @@ static char *strcond[16] = {
 //	%R int		Registers
 //
 //	%$ char*	String constant addresses (for internal use only)
+//      %^ int          C_* classes (for liblink internal use)
 
 #pragma	varargck	type	"$"	char*
 #pragma	varargck	type	"M"	Addr*
@@ -60,6 +62,9 @@ listinit7(void)
 	fmtinstall('D', Dconv);
 	fmtinstall('P', Pconv);
 	fmtinstall('R', Rconv);
+
+        // for liblink internal use
+        fmtinstall('^', DRconv);
 
 	// for internal use
 	fmtinstall('$', DSconv);
@@ -317,6 +322,19 @@ Rconv(Fmt *fp)
 	r = va_arg(fp->args, int);
 	sprint(str, "R%d", r);
 	return fmtstrcpy(fp, str);
+}
+
+static int
+DRconv(Fmt *fp)
+{
+        char *s;
+        int a;
+
+        a = va_arg(fp->args, int);
+        s = "C_??";
+        if(a >= C_NONE && a <= C_NCLASS)
+                s = cnames7[a];
+        return fmtstrcpy(fp, s);
 }
 
 static int


### PR DESCRIPTION
Add `DRConv`, `%^` formatted printing (like 5g and 9g)

Helps, but doesn't solve

```
rugby(~/src) % ../go.arm64/pkg/tool/linux_arm64/7g x.go                                                                                                                                       
00016 (x.go:4)  CMP     R9,R10
00016 (x.go:4)  CMP     R9,R10
00020 (x.go:9)  CMP     R9,R10
00044 (x.go:9)  CMP     R9,R10
00064 (x.go:9)  UNDEF   ,
00020 (x.go:9)  CMP     R9,R10
00044 (x.go:9)  CMP     R9,R10
00064 (x.go:9)  UNDEF   ,
x.go:9: illegal combination 00016 (x.go:4)      CMP     R9,R10 REG NONE         = 0 REG, 14 14
x.go:9: illegal combination 00020 (x.go:9)      CMP     R9,R10 REG NONE         = 0 REG, 14 14
x.go:9: illegal combination 00044 (x.go:9)      CMP     R9,R10 REG NONE         = 0 REG, 14 14
x.go:9: illegal combination 00064 (x.go:9)      UNDEF   , NONE          = 0 NONE                = 0 NONE                = 0, 1 1
x.go:9: illegal combination 00020 (x.go:9)      CMP     R9,R10 REG NONE         = 0 REG, 14 14
x.go:9: illegal combination 00044 (x.go:9)      CMP     R9,R10 REG NONE         = 0 REG, 14 14
x.go:9: illegal combination 00064 (x.go:9)      UNDEF   , NONE          = 0 NONE                = 0 NONE                = 0, 1 1
```
