### PR TITLE
liblink: add support for CMP Reg, Reg

### DIFF
--- a/src/liblink/asm7.c
+++ b/src/liblink/asm7.c
@@ -190,6 +190,7 @@ static Optab optab[] = {
 
 	{ AADD,		C_REG,	C_REG,	C_REG,		 1, 4, 0 },
 	{ AADD,		C_REG,	C_NONE,	C_REG,		 1, 4, 0 },
+	{ ACMP,		C_REG,  C_NONE, C_REG,		 3, 4, 0 },
 
 	/* logical operations */
 	{ AAND,		C_REG,	C_REG,	C_REG,		 1, 4, 0 },


### PR DESCRIPTION
CMP Reg, Reg is encoded like ADD (shifted)
