### PR TITLE
runtime: remove all uses of float and complex types in alg.go

### DIFF
--- a/src/runtime/alg.go
+++ b/src/runtime/alg.go
@@ -105,28 +105,36 @@ func strhash(a unsafe.Pointer, s, h uintptr) uintptr {
 // To avoid long hash chains, we assign a random number
 // as the hash value for a NaN.
 
+func f32zero(p unsafe.Pointer) bool {
+        return *(*uint32)(p) & 0x7fffffff == 0
+}
+
 func f32hash(p unsafe.Pointer, s, h uintptr) uintptr {
-	f := *(*float32)(p)
-	switch {
-	case f == 0:
-		return c1 * (c0 ^ h) // +0, -0
-	case f != f:
-		return c1 * (c0 ^ h ^ uintptr(fastrand1())) // any kind of NaN
-	default:
-		return memhash(p, 4, h)
-	}
+        f := *(*float32)(p)
+        switch {
+        case f32zero(p):
+                return c1 * (c0 ^ h) // +0, -0
+        case f != f:
+                return c1 * (c0 ^ h ^ uintptr(fastrand1())) // any kind of NaN
+        default:
+                return memhash(p, 4, h)
+        }
+}
+
+func f64zero(p unsafe.Pointer) bool {
+        return *(*uintptr)(p) & 0x7fffffffffffffff == 0
 }
 
 func f64hash(p unsafe.Pointer, s, h uintptr) uintptr {
-	f := *(*float64)(p)
-	switch {
-	case f == 0:
-		return c1 * (c0 ^ h) // +0, -0
-	case f != f:
-		return c1 * (c0 ^ h ^ uintptr(fastrand1())) // any kind of NaN
-	default:
-		return memhash(p, 8, h)
-	}
+        f := *(*float64)(p)
+        switch {
+        case f64zero(p):
+                return c1 * (c0 ^ h) // +0, -0
+        case f != f:
+                return c1 * (c0 ^ h ^ uintptr(fastrand1())) // any kind of NaN
+        default:
+                return memhash(p, 8, h)
+        }
 }
 
 func c64hash(p unsafe.Pointer, s, h uintptr) uintptr {

--- a/src/runtime/alg.go
+++ b/src/runtime/alg.go
@@ -264,10 +264,12 @@ func f64equal(p, q unsafe.Pointer, size uintptr) bool {
         return *(*uint64)(p) == *(*uint64)(q)
 }
 func c64equal(p, q unsafe.Pointer, size uintptr) bool {
-	return *(*complex64)(p) == *(*complex64)(q)
+        cp, cq := *(*struct{r, i uint32})(p), *(*struct{r, i uint32})(q)
+        return f32equal(unsafe.Pointer(&cp.r), unsafe.Pointer(&cq.r), 0) && f32equal(unsafe.Pointer(&cq.i), unsafe.Pointer(&cq.i), 0)
 }
 func c128equal(p, q unsafe.Pointer, size uintptr) bool {
-	return *(*complex128)(p) == *(*complex128)(q)
+        cp, cq := *(*struct{r, i uint64})(p), *(*struct{r, i uint64})(q)
+        return f64equal(unsafe.Pointer(&cp.r), unsafe.Pointer(&cq.r), 0) && f64equal(unsafe.Pointer(&cq.i), unsafe.Pointer(&cq.i), 0)
 }
 func strequal(p, q unsafe.Pointer, size uintptr) bool {
 	return *(*string)(p) == *(*string)(q)

--- a/src/runtime/alg.go
+++ b/src/runtime/alg.go
@@ -176,12 +176,12 @@ func f64hash(p unsafe.Pointer, s, h uintptr) uintptr {
 }
 
 func c64hash(p unsafe.Pointer, s, h uintptr) uintptr {
-	x := (*[2]float32)(p)
+	x := (*[2]uint32)(p)
 	return f32hash(unsafe.Pointer(&x[1]), 4, f32hash(unsafe.Pointer(&x[0]), 4, h))
 }
 
 func c128hash(p unsafe.Pointer, s, h uintptr) uintptr {
-	x := (*[2]float64)(p)
+	x := (*[2]uint64)(p)
 	return f64hash(unsafe.Pointer(&x[1]), 8, f64hash(unsafe.Pointer(&x[0]), 8, h))
 }
 

--- a/src/runtime/alg.go
+++ b/src/runtime/alg.go
@@ -109,12 +109,31 @@ func f32zero(p unsafe.Pointer) bool {
         return *(*uint32)(p) & 0x7fffffff == 0
 }
 
+func f32nan(p unsafe.Pointer) bool {
+        f32 := *(*uint32)(p)
+        switch {
+        case f32 >= 0x7f800001 && f32 <= 0x7ffbffff:
+                // signalling positive nan
+                return true
+        case f32 >= 0xFF800001 && f32 <= 0xFFBFFFFF:
+                // signalling negative nan
+                return true
+        case f32 >= 0x7FC00000 && f32 <= 0x7FFFFFFF:
+                // quiet positive nan
+                return true
+        case f32 >= 0xFFC00000 && f32 <= 0xFFFFFFFF:
+		// quiet negative nan
+                return true
+        default:
+                return false
+        }
+}
+
 func f32hash(p unsafe.Pointer, s, h uintptr) uintptr {
-        f := *(*float32)(p)
         switch {
         case f32zero(p):
                 return c1 * (c0 ^ h) // +0, -0
-        case f != f:
+        case f32nan(p):
                 return c1 * (c0 ^ h ^ uintptr(fastrand1())) // any kind of NaN
         default:
                 return memhash(p, 4, h)
@@ -125,12 +144,31 @@ func f64zero(p unsafe.Pointer) bool {
         return *(*uintptr)(p) & 0x7fffffffffffffff == 0
 }
 
+func f64nan(p unsafe.Pointer) bool {
+        f64 := *(*uint64)(p)
+        switch {
+        case f64 >= 0x7FF0000000000001 && f64 <= 0x7FF7FFFFFFFFFFFF:
+                // signalling positive nan
+                return true
+        case f64 >= 0xFFF0000000000001 && f64 <= 0xFFF0000000000001:
+                // signalling negative nan
+                return true
+        case f64 >= 0x7FF8000000000000 && f64 <= 0x7FFFFFFFFFFFFFFF:
+                // quiet positive nan
+                return true
+        case f64 >= 0xFFF8000000000000 && f64 <= 0xFFFFFFFFFFFFFFFF:
+		// quiet negative nan
+                return true
+        default:
+                return false
+        }
+}
+
 func f64hash(p unsafe.Pointer, s, h uintptr) uintptr {
-        f := *(*float64)(p)
         switch {
         case f64zero(p):
                 return c1 * (c0 ^ h) // +0, -0
-        case f != f:
+        case f64nan(p):
                 return c1 * (c0 ^ h ^ uintptr(fastrand1())) // any kind of NaN
         default:
                 return memhash(p, 8, h)
@@ -208,10 +246,22 @@ func memequal128(p, q unsafe.Pointer, size uintptr) bool {
 	return *(*[2]int64)(p) == *(*[2]int64)(q)
 }
 func f32equal(p, q unsafe.Pointer, size uintptr) bool {
-	return *(*float32)(p) == *(*float32)(q)
+        if f32zero(p) && f32zero(q) {
+                return true // negative or postive zero are equal
+        }
+        if f32nan(p) || f32nan(q) {
+                return false // nan is never equal to anything, even nan
+        }
+        return *(*uint32)(p) == *(*uint32)(q)
 }
 func f64equal(p, q unsafe.Pointer, size uintptr) bool {
-	return *(*float64)(p) == *(*float64)(q)
+        if f64zero(p) && f64zero(q) {
+                return true // negative or postive zero are equal
+        }
+        if f64nan(p) || f64nan(q) {
+                return false // nan is never equal to anything, even nan
+        }
+        return *(*uint64)(p) == *(*uint64)(q)
 }
 func c64equal(p, q unsafe.Pointer, size uintptr) bool {
 	return *(*complex64)(p) == *(*complex64)(q)


### PR DESCRIPTION
7g can't handle float or complex types at the moment. Until the compiler can handle these types, replace the map alg.go functions with bit twiddling.
