### PR TITLE
runtime: hide sqrt.go from arm64

### DIFF
--- a/src/runtime/complex.go
+++ b/src/runtime/complex.go
@@ -4,6 +4,8 @@
 
 package runtime
 
+const maxFloat64 = 1.797693134862315708145274237317043567981e+308 // 2**1023 * (2**53 - 1) / 2**52
+
 func isposinf(f float64) bool { return f > maxFloat64 }
 func isneginf(f float64) bool { return f < -maxFloat64 }
 func isnan(f float64) bool    { return f != f }

--- a/src/runtime/sqrt_arm.go
+++ b/src/runtime/sqrt_arm.go
@@ -89,7 +89,6 @@ const (
 	mask       = 0x7FF
 	shift      = 64 - 11 - 1
 	bias       = 1023
-	maxFloat64 = 1.797693134862315708145274237317043567981e+308 // 2**1023 * (2**53 - 1) / 2**52
 )
 
 func float64bits(f float64) uint64     { return *(*uint64)(unsafe.Pointer(&f)) }


### PR DESCRIPTION
This PR is in two parts. This first part, which I want to send upstream makes sqrt visible only to arm builds. This necessitates moving one constant into complex.go.

This still leaves complex.go with float64 references, but I'll address that in the next PR.
