### PR TITLE
runtime: hiding more float and complex types

### DIFF
--- a/src/runtime/complex.go
+++ b/src/runtime/complex.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !arm64
+
 package runtime
 
 func isposinf(f float64) bool { return f > maxFloat64 }

--- a/src/runtime/print1.go
+++ b/src/runtime/print1.go
@@ -156,10 +156,10 @@ func vprintf(str string, arg unsafe.Pointer) {
 			printint(int64(*(*int64)(arg)))
 		case 'e':
 			printeface(*(*interface{})(arg))
-		case 'f':
-			printfloat(*(*float64)(arg))
-		case 'C':
-			printcomplex(*(*complex128)(arg))
+//		case 'f':
+//			printfloat(*(*float64)(arg))
+//		case 'C':
+//			printcomplex(*(*complex128)(arg))
 		case 'i':
 			printiface(*(*fInterface)(arg))
 		case 'p':
@@ -202,7 +202,7 @@ func printbool(v bool) {
 func printbyte(c byte) {
 	gwrite((*[1]byte)(unsafe.Pointer(&c))[:])
 }
-
+/*
 func printfloat(v float64) {
 	switch {
 	case v != v:
@@ -274,10 +274,13 @@ func printfloat(v float64) {
 	buf[n+6] = byte(e%10) + '0'
 	gwrite(buf[:])
 }
+*/
 
+/*
 func printcomplex(c complex128) {
 	print("(", real(c), imag(c), "i)")
 }
+*/
 
 func printuint(v uint64) {
 	var buf [100]byte

--- a/src/runtime/runtime1.go
+++ b/src/runtime/runtime1.go
@@ -145,8 +145,8 @@ func check() {
 		f     uint32
 		g     int64
 		h     uint64
-		i, i1 float32
-		j, j1 float64
+		// i, i1 float32
+		// j, j1 float64
 		k, k1 unsafe.Pointer
 		l     *uint16
 		m     [4]byte
@@ -185,12 +185,14 @@ func check() {
 	if unsafe.Sizeof(h) != 8 {
 		gothrow("bad h")
 	}
+	/*
 	if unsafe.Sizeof(i) != 4 {
 		gothrow("bad i")
 	}
 	if unsafe.Sizeof(j) != 8 {
 		gothrow("bad j")
 	}
+	*/
 	if unsafe.Sizeof(k) != ptrSize {
 		gothrow("bad k")
 	}
@@ -257,6 +259,7 @@ func check() {
 		gothrow("atomicor8")
 	}
 
+	/*
 	*(*uint64)(unsafe.Pointer(&j)) = ^uint64(0)
 	if j == j {
 		gothrow("float64nan")
@@ -288,7 +291,7 @@ func check() {
 	if i == i1 {
 		gothrow("float32nan3")
 	}
-
+	*/
 	testAtomic64()
 
 	if _FixedStack != round2(_FixedStack) {


### PR DESCRIPTION
`complex.go` cannot be compiled by 7g at the moment, any time the compiler sees a complex128 it thinks that it is a [2]float64 anyway, so hide that in the arm64 build. The runtime won't link, but that isn't the biggest problem now.

`print1.go`, same, float64 and complex128 types visible, so comment them out.

`runtime1.go`, comment out the startup sanity checks for types we can't handle.
