### PR TITLE
runtime: remove the use of flot64 in mprof.go

### DIFF
--- a/src/runtime/mprof.go
+++ b/src/runtime/mprof.go
@@ -279,7 +279,7 @@ func SetBlockProfileRate(rate int) {
 		r = 1 // profile everything
 	} else {
 		// convert ns to cycles, use float64 to prevent overflow during multiplication
-		r = int64(float64(rate) * float64(tickspersecond()) / (1000 * 1000 * 1000))
+		r = int64(rate) * (tickspersecond() / (1000 * 1000 * 1000))
 		if r == 0 {
 			r = 1
 		}


### PR DESCRIPTION
If `tickspersecond` drops below 10^9 then profiling won't work, but that doens't feel like a big problem.
