### PR TITLE
cmd/7g: fix unary OMINUS

### DIFF
--- a/src/cmd/7g/cgen.c
+++ b/src/cmd/7g/cgen.c
@@ -246,14 +246,13 @@ cgen(Node *n, Node *res)
 		goto ret;
 
 	case OMINUS:
-		if(isfloat[nl->type->etype]) {
-			nr = nodintconst(-1);
-			convlit(&nr, n->type);
-			a = optoas(OMUL, nl->type);
-			goto sbop;
-		}
-		a = optoas(n->op, nl->type);
-		goto uop;
+		regalloc(&n1, nl->type, N);
+		cgen(nl, &n1);
+		nodconst(&n2, nl->type, 0);
+		gins(optoas(OMINUS, nl->type), &n2, &n1);
+		gmove(&n1, res);
+		regfree(&n1);
+		goto ret;
 
 	// symmetric binary
 	case OAND:
@@ -544,16 +543,6 @@ abop:	// asymmetric binary
 	regfree(&n1);
 	if(n2.op != OLITERAL)
 		regfree(&n2);
-	goto ret;
-
-uop:	// unary
-	regalloc(&n1, nl->type, res);
-	cgen(nl, &n1);
-	gins(a, N, &n1);
-	gmove(&n1, res);
-	regfree(&n1);
-	goto ret;
-
 ret:
 	;
 }

--- a/src/cmd/7g/ggen.c
+++ b/src/cmd/7g/ggen.c
@@ -198,8 +198,8 @@ ginscall(Node *f, int proc)
 				// ARM64 NOP is really HINT $0
 				// Use the latter form because the NOP pseudo-instruction
 				// would be removed by the linker.
-				nodconst(&con, types[TINT], argsize(f->type));
-				gins(AHINT, &con, N);
+				nodreg(&reg, types[TINT], D_R0);
+				gins(AMOV, &reg, &reg);
 			}
 			p = gins(ABL, N, f);
 			afunclit(&p->to, f);
@@ -571,7 +571,8 @@ dodiv(int op, Node *nl, Node *nr, Node *res)
 		p1 = gbranch(optoas(ONE, t), T, +1);
 		if(op == ODIV) {
 			// a / (-1) is -a.
-			gins(optoas(OMINUS, t), N, &tl);
+			nodconst(&nz, t, 0);
+			gins(optoas(OMINUS, t), &nz, &tl);
 			gmove(&tl, res);
 		} else {
 			// a % (-1) is 0.


### PR DESCRIPTION
Unary OMINUS was all messed up, so port over the 5g version. In the process the unused uop: label and code was found to be unused.
