### PR TITLE
make the cname for C_NONE nicer

### DIFF
--- a/src/cmd/7l/7.out.h
+++ b/src/cmd/7l/7.out.h
@@ -51,7 +51,7 @@ enum {
 
 enum
 {
-	C_NONE		= 0,
+	C_NONE,
 	C_REG,
 	C_RSP,		/* D_REG or D_SP */
 	C_SHIFT,		/* D_SHIFT: shift type, amount, value */


### PR DESCRIPTION
This almost seems frivolous, but cnames[C_NONE] is not very friendly currently (it has 2 tabs in!):

```
runtime/alg.go:1: illegal combination 01064 (<unknown line number>) DWORD   ,$2162728(R7) NONE      = 0 NONE        = 0 LACON, 1 10
```

the first element of an enum is 0 anyway, so this drops the initializer.  (Or we could make mkanames or whatever it's called smarter)
