### PR TITLE
liblink: avoid overrunning symbol buffer in span7

### DIFF
--- a/src/liblink/asm7.c
+++ b/src/liblink/asm7.c
@@ -701,6 +701,11 @@ span7(Link *ctxt, LSym *cursym)
 			*(int32*)bp = 0;
 			bp += 4;
 			psz += 4;
+			cursym->size += 4;
+			if (cursym->size >= cursym->maxp) {
+				symgrow(ctxt, cursym, cursym->size);
+				bp = cursym->p;
+			}
 		}
 		if(o->size > 4*nelem(out))
 			sysfatal("out array in span7 is too small, need at least %d for %P", o->size/4, p);


### PR DESCRIPTION
Aligning DWORDs onto 8 byte boundaries can make a function take up
more space than the code expects and overrun the buffer.  This was
causing realloc() to abort with an "invalid pointer" error, I guess
because it was corrupting glibc's heap data.

This fixes by checking to see if the padding will cause the buffer to
overflow and resizing it again.

Change-Id: Ic4b2a1a478765d86812fd329762de8cd2ff7802d
