### PR TITLE
runtime: start a couple of arm64 assembly files

### DIFF
--- a/src/runtime/asm_arm64.s
+++ b/src/runtime/asm_arm64.s
@@ -1,0 +1,7 @@
+#include "go_asm.h"
+#include "go_tls.h"
+#include "funcdata.h"
+#include "textflag.h"
+
+TEXT runtime·rt0_go(SB),NOSPLIT,$0
+        RET

--- a/src/runtime/rt0_linux_arm64.s
+++ b/src/runtime/rt0_linux_arm64.s
@@ -1,0 +1,13 @@
+#include "textflag.h"
+
+TEXT _rt0_arm64_linux(SB),NOSPLIT,$0
+	B _main<>(SB)
+
+TEXT _main<>(SB),NOSPLIT,$-8
+	MOV 0(SP), R3 // argc
+	ADD $8, SP, R4 // argv
+	B main(SB)
+
+TEXT main(SB),NOSPLIT,$-8
+	MOV	$runtime·rt0_go(SB), R0
+	B	(R0)


### PR DESCRIPTION
With this and passing -ldflags -w to avoid issue #29 I can compile a trivial go program into a binary.  It doesn't come anywhere nearly close to working, of course, but it's a start.
