### PR TITLE
cmd/7a: recognize register g, and not R29.

### DIFF
--- a/src/cmd/7a/lex.c
+++ b/src/cmd/7a/lex.c
@@ -206,7 +206,7 @@ struct
 	"R26",		LREG,	26,
 	"R27",		LREG,	27,
 	"R28",		LREG,	28,
-	"R29",		LREG,	29,
+	"g",		LREG,	29, // avoid unintentionally clobbering g using R29
 	"R30",		LREG,	30,
 	"LR",			LREG,	30,
 	"ZR",			LREG,	31,


### PR DESCRIPTION
It brings the assembler in line with 5a and 9a.

Fixes #35.
