### PR TITLE
cmd/7g: fix floating OMINUS

### DIFF
--- a/src/cmd/7g/cgen.c
+++ b/src/cmd/7g/cgen.c
@@ -246,6 +246,12 @@ cgen(Node *n, Node *res)
 		goto ret;
 
 	case OMINUS:
+		if(isfloat[nl->type->etype]) {
+			nr = nodintconst(-1);
+			convlit(&nr, n->type);
+			a = optoas(OMUL, nl->type);
+			goto sbop;
+		}
 		regalloc(&n1, nl->type, N);
 		cgen(nl, &n1);
 		nodconst(&n2, nl->type, 0);


### PR DESCRIPTION
restore code dave removed when fixing OMINUS for integers...

fixes compilation of -x where x is a float
