### PR TITLE
runtime: add os_linux_arm64.go

### DIFF
--- a/src/runtime/cputicks.go
+++ b/src/runtime/cputicks.go
@@ -3,6 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // +build !arm
+// +build !arm64
 
 package runtime
 

--- a/src/runtime/os_linux_arm64.go
+++ b/src/runtime/os_linux_arm64.go
@@ -1,0 +1,46 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import "unsafe"
+
+const (
+	_AT_NULL   = 0
+	_AT_RANDOM = 25 // introduced in 2.6.29
+)
+
+var randomNumber uint32
+
+func sysargs(argc int32, argv **byte) {
+	// skip over argv, envv to get to auxv
+	n := argc + 1
+	for argv_index(argv, n) != nil {
+		n++
+	}
+	n++
+	auxv := (*[1 << 32]uint64)(add(unsafe.Pointer(argv), uintptr(n)*ptrSize))
+
+	for i := 0; auxv[i] != _AT_NULL; i += 2 {
+		switch auxv[i] {
+		case _AT_RANDOM: // kernel provides a pointer to 16-bytes worth of random data
+			startupRandomData = (*[16]byte)(unsafe.Pointer(uintptr(auxv[i+1])))[:]
+			// the pointer provided may not be word alined, so we must to treat it
+			// as a byte array.
+			randomNumber = uint32(startupRandomData[4]) | uint32(startupRandomData[5])<<8 |
+				uint32(startupRandomData[6])<<16 | uint32(startupRandomData[7])<<24
+		}
+	}
+}
+
+func cputicks() int64 {
+	// Currently cputicks() is used in blocking profiler and to seed fastrand1().
+	// nanotime() is a poor approximation of CPU ticks that is enough for the profiler.
+	// randomNumber provides better seeding of fastrand1.
+	return nanotime() + int64(randomNumber)
+}

--- a/src/runtime/vdso_none.go
+++ b/src/runtime/vdso_none.go
@@ -4,6 +4,7 @@
 
 // +build !linux !amd64
 // +build !linux !386
+// +build !linux !arm64
 
 package runtime
 


### PR DESCRIPTION
Adds sysargs and cputicks. Work is going on upstream to unify this code so auxv parsing can be shared across all linux platforms.
