### PR TITLE
liblink: handle more constant classes in addpool

### DIFF
--- a/src/liblink/asm7.c
+++ b/src/liblink/asm7.c
@@ -826,6 +826,8 @@ addpool(Link *ctxt, Prog *p, Addr *a)
 	case C_LOREG:
 	case C_LACON:
 	case C_AACON:
+	case C_ABCON:
+	case C_MBCON:
 		t.to.type = D_CONST;
 		t.to.offset = ctxt->instoffset;
 		break;


### PR DESCRIPTION
Updates #62. We still need to figure out why MOV $"".p+CONST, R3
uses constant pool at all when CONST is directly encodable.
