### PR TITLE
liblink: encode stlr stlrw correctly

### DIFF
--- a/src/cmd/7g/ggen.c
+++ b/src/cmd/7g/ggen.c
@@ -176,6 +176,7 @@ ginscall(Node *f, int proc)
 {
 	Prog *p;
 	Node reg, con, reg2;
+	Node r1;
 	int32 extra;
 
 	if(f->type != T) {
@@ -213,9 +214,14 @@ ginscall(Node *f, int proc)
 			break;
 		}
 		nodreg(&reg, types[tptr], D_R0+REGENV);
+		nodreg(&r1, types[tptr], D_R0+3);
 		gmove(f, &reg);
 		reg.op = OINDREG;
-		gins(ABL, N, &reg);
+		gmove(&reg, &r1);
+		//reg.op = OREGISTER;
+		r1.op = OINDREG;
+		//gins(ABL, &reg, &r1);
+		gins(ABL, N, &r1);
 		break;
 	
 	case 3:	// normal call of c function pointer

--- a/src/cmd/internal/obj/arm64/asm7.go
+++ b/src/cmd/internal/obj/arm64/asm7.go
@@ -503,7 +503,7 @@ var optab = []Optab{
 	Optab{ALDXR, C_ZOREG, C_NONE, C_REG, 58, 4, 0, 0},
 	Optab{ALDAXR, C_ZOREG, C_NONE, C_REG, 58, 4, 0, 0},
 	Optab{ALDXP, C_ZOREG, C_REG, C_REG, 58, 4, 0, 0},
-	Optab{ASTLR, C_REG, C_NONE, C_ZOREG, 59, 4, 0, 0},  // to3=C_NONE
+	Optab{ASTLR, C_REG, C_NONE, C_ZOREG, 66, 4, 0, 0},  // to3=C_NONE
 	Optab{ASTXR, C_REG, C_NONE, C_ZOREG, 59, 4, 0, 0},  // to3=C_REG
 	Optab{ASTLXR, C_REG, C_NONE, C_ZOREG, 59, 4, 0, 0}, // to3=C_REG
 	Optab{ASTXP, C_REG, C_NONE, C_ZOREG, 59, 4, 0, 0},  // to3=C_REG
@@ -2924,6 +2924,19 @@ func asmout(ctxt *obj.Link, p *obj.Prog, o *Optab, out []uint32) {
 			break
 		}
 		o2 = olsr12u(ctxt, int32(opldr12(ctxt, int(p.As))), 0, REGTMP, int(p.To.Reg))
+        case 66: /* stlr/stlrw */
+                o1 = opstore(ctxt, int(p.As))
+
+                o1 |= 0x1F << 16
+                o1 |= uint32(p.From.Reg) << 5
+                if p.Reg != NREG {
+                        o1 |= uint32(p.Reg) << 10
+                } else {
+
+                        o1 |= 0x1F << 10
+                }
+                o1 |= uint32(p.To.Reg)
+
 
 		// This is supposed to be something that stops execution.
 	// It's not supposed to be reached, ever, but if it is, we'd

--- a/src/liblink/asm7.c
+++ b/src/liblink/asm7.c
@@ -635,7 +635,7 @@ static Optab optab[] = {
 	{ ALDXR,		C_ZOREG,	C_NONE,	C_REG,		58, 4, 0 },
 	{ ALDAXR,		C_ZOREG,	C_NONE,	C_REG,		58, 4, 0 },
 	{ ALDXP,		C_ZOREG,	C_REG,	C_REG,		58, 4, 0 },
-	{ ASTLR,		C_REG,	C_NONE,	C_ZOREG,		59, 4, 0 },	// to3=C_NONE
+	{ ASTLR,		C_REG,	C_NONE,	C_ZOREG,		66, 4, 0 }, // to3=C_NONE
 	{ ASTXR,		C_REG,	C_NONE,	C_ZOREG,		59, 4, 0 }, // to3=C_REG
 	{ ASTLXR,		C_REG,	C_NONE,	C_ZOREG,		59, 4, 0 }, // to3=C_REG
 	{ ASTXP,		C_REG, C_NONE,	C_ZOREG,		59, 4, 0 }, // to3=C_REG
@@ -2691,6 +2691,17 @@ if(0 /*debug['P']*/) print("%ux: %P	type %d\n", (uint32)(p->pc), p, o->type);
 			break;
 		o2 = olsr12u(ctxt, opldr12(ctxt, p->as), 0, REGTMP, p->to.reg);
 		break;
+       case 66: /* stlr /stlrw */
+               o1 = opstore(ctxt, p->as);
+                o1 |= 0x1F << 16;
+                o1 |= p->from.reg << 5;
+                if(p->reg != NREG)
+                        o1 |= p->reg << 10;
+                else
+                        o1 |= 0x1F << 10;
+                o1 |= p->to.reg;
+               break;
+
 	case 90:
 		// This is supposed to be something that stops execution.
 		// It's not supposed to be reached, ever, but if it is, we'd

--- a/src/runtime/atomic_arm.go
+++ b/src/runtime/atomic_arm.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build arm arm64
-
 package runtime
 
 import "unsafe"

--- a/src/runtime/atomic_arm64.go
+++ b/src/runtime/atomic_arm64.go
@@ -1,0 +1,61 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package runtime
+
+import "unsafe"
+
+//go:noescape
+func xadd(ptr *uint32, delta int32) uint32
+
+//go:noescape
+func xadd64(ptr *uint64, delta int64) uint64
+
+//go:noescape
+func xchg(ptr *uint32, new uint32) uint32
+
+//go:noescape
+func xchg64(ptr *uint64, new uint64) uint64
+
+// NO go:noescape annotation; see atomic_pointer.go.
+func xchgp1(ptr unsafe.Pointer, new unsafe.Pointer) unsafe.Pointer
+
+//go:noescape
+func xchguintptr(ptr *uintptr, new uintptr) uintptr
+
+//go:noescape
+func atomicload(ptr *uint32) uint32
+
+//go:noescape
+func atomicload64(ptr *uint64) uint64
+
+//go:noescape
+func atomicloadp(ptr unsafe.Pointer) unsafe.Pointer
+
+//go:nosplit
+func atomicor8(addr *uint8, v uint8) {
+	// TODO(dfc) implement this in asm.
+        // Align down to 4 bytes and use 32-bit CAS.
+        uaddr := uintptr(unsafe.Pointer(addr))
+        addr32 := (*uint32)(unsafe.Pointer(uaddr &^ 3))
+        word := uint32(v) << ((uaddr & 3) * 8) // little endian
+        for {
+                old := *addr32
+                if cas(addr32, old, old|word) {
+                        return
+                }
+        }
+}
+
+//go:noescape
+func cas64(ptr *uint64, old, new uint64) bool
+
+//go:noescape
+func atomicstore(ptr *uint32, val uint32)
+
+//go:noescape
+func atomicstore64(ptr *uint64, val uint64)
+
+// NO go:noescape annotation; see atomic_pointer.go.
+func atomicstorep1(ptr unsafe.Pointer, val unsafe.Pointer)

--- a/src/runtime/atomic_arm64.s
+++ b/src/runtime/atomic_arm64.s
@@ -1,0 +1,110 @@
+// Copyright 2014 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+// uint32 runtime·atomicload(uint32 volatile* addr)
+TEXT ·atomicload(SB),NOSPLIT,$-8-12
+	MOV	addr+0(FP), R0
+	LDARW	(R0), R0
+	MOVW	R0, val+8(FP)
+	RETURN
+
+// uint64 runtime·atomicload64(uint64 volatile* addr)
+TEXT ·atomicload64(SB),NOSPLIT,$-8-16
+	MOV	addr+0(FP), R0
+	LDAR	(R0), R0
+	MOV	R0, val+8(FP)
+	RETURN
+
+// void *runtime·atomicloadp(void *volatile *addr)
+TEXT ·atomicloadp(SB),NOSPLIT,$-8-16
+	MOV	addr+0(FP), R0
+	LDAR	(R0), R0
+	MOV	R0, val+8(FP)
+	RETURN
+
+TEXT runtime·atomicstorep1(SB), NOSPLIT, $0-16
+	B	runtime·atomicstore64(SB)
+
+TEXT runtime·atomicstore(SB), NOSPLIT, $0-12
+	MOV	addr+0(FP), R0
+	MOVW	val+8(FP), R1
+	STLRW	R1, (R0)
+	RETURN
+
+TEXT runtime·atomicstore64(SB), NOSPLIT, $0-16
+	MOV	addr+0(FP), R0
+	MOV	val+8(FP), R1
+	STLR	R1, (R0)
+	RETURN
+
+TEXT runtime·xchg(SB), NOSPLIT, $0-20
+again:
+	MOV	addr+0(FP), R0
+	MOVW	new+8(FP), R1
+	LDAXR	(R0), R2
+	STLXRW	R1, (R0), R3
+	CBNZ	R3, again
+	MOVW	R2, old+16(FP)
+	RETURN
+
+TEXT runtime·xchg64(SB), NOSPLIT, $0-24
+again:
+	MOV	addr+0(FP), R0
+	MOV	new+8(FP), R1
+	LDAXR	(R0), R2
+	STLXR	R1, (R0), R3
+	CBNZ	R3, again
+	MOV	R2, old+16(FP)
+	RETURN
+
+// bool runtime·cas64(uint64 *ptr, uint64 old, uint64 new)
+// Atomically:
+//      if(*val == *old){
+//              *val = new;
+//              return 1;
+//      } else {
+//              return 0;
+//      }
+TEXT runtime·cas64(SB), NOSPLIT, $0-25
+	MOV	addr+0(FP), R0
+	MOV	old+8(FP), R1
+	MOV	new+16(FP), R2
+again:
+	LDAXR	(R0), R3
+	CMP	R1, R3
+	BNE	ok
+	STLXR	R2, (R0), R3
+	CBNZ	R3, again
+ok:
+	CSET	EQ, R0
+	MOVB	R0, swapped+24(FP)
+	RETURN
+
+// uint32 xadd(uint32 volatile *ptr, int32 delta)
+// Atomically:
+//      *val += delta;
+//      return *val;
+TEXT runtime·xadd(SB), NOSPLIT, $0-20
+again:
+	MOV	addr+0(FP), R0
+	MOVW	delta+8(FP), R1
+	LDAXRW	(R0), R2
+	ADDW	R2, R1, R2
+	STLXRW	R2, (R0), R3
+	CBNZ	R3, again
+	MOVW	R2, new+16(FP)
+	RETURN
+
+TEXT runtime·xadd64(SB), NOSPLIT, $0-24
+again:
+	MOV	addr+0(FP), R0
+	MOV	delta+8(FP), R1
+	LDAXR	(R0), R2
+	ADD	R2, R1, R2
+	STLXR	R2, (R0), R3
+	CBNZ	R3, again
+	MOV	R2, new+16(FP)
+	RETURN


### PR DESCRIPTION
gdb is now happy

```
(gdb) disassemble 'runtime.atomicstore'  
Dump of assembler code for function runtime.atomicstore:
   0x0000000000124730 <+0>:     ldr     x0, [sp,#8]
   0x0000000000124734 <+4>:     ldrsw   x1, [sp,#16]
   0x0000000000124738 <+8>:     stlr    w0, [x1]
   0x000000000012473c <+12>:    ret
End of assembler dump.
(gdb) disassemble 'runtime.atomicstore64'
Dump of assembler code for function runtime.atomicstore64:
   0x0000000000124740 <+0>:     ldr     x0, [sp,#8]
   0x0000000000124744 <+4>:     ldr     x1, [sp,#16]
   0x0000000000124748 <+8>:     stlr    x0, [x1]
   0x000000000012474c <+12>:    ret
End of assembler dump.
```

Requires #81, #83 
