### PR TITLE
liblink: bug fixes for ppc64 %P format

### DIFF
--- a/src/liblink/list9.c
+++ b/src/liblink/list9.c
@@ -92,18 +92,19 @@ Pconv(Fmt *fp)
 	bigP = p;
 	a = p->as;
 
+	str[0] = 0;
 	if(a == ADATA || a == AINIT || a == ADYNT)
 		sprint(str, "%.5lld (%L)	%A	%D/%d,%D", p->pc, p->lineno, a, &p->from, p->reg, &p->to);
 	else if(a == ATEXT) {
 		if(p->reg != 0)
-			sprint(str, "%.5lld (%L)        %A      %D,%d,%lD", p->pc, p->lineno, a, &p->from, p->reg, &p->to);
+			sprint(str, "%.5lld (%L)	%A	%D,%d,%lD", p->pc, p->lineno, a, &p->from, p->reg, &p->to);
 		else
-			sprint(str, "%.5lld (%L)        %A      %D,%lD", p->pc, p->lineno, a, &p->from, &p->to);
+			sprint(str, "%.5lld (%L)	%A	%D,%lD", p->pc, p->lineno, a, &p->from, &p->to);
 	} else if(a == AGLOBL) {
 		if(p->reg != 0)
-			sprint(str, "%.5lld (%L)        %A      %D,%d,%D", p->pc, p->lineno, a, &p->from, p->reg, &p->to);
+			sprint(str, "%.5lld (%L)	%A	%D,%d,%D", p->pc, p->lineno, a, &p->from, p->reg, &p->to);
 		else
-			sprint(str, "%.5lld (%L)        %A      %D,%D", p->pc, p->lineno, a, &p->from, &p->to);
+			sprint(str, "%.5lld (%L)	%A	%D,%D", p->pc, p->lineno, a, &p->from, &p->to);
 	} else {
 		if(p->mark & NOSCHED)
 			sprint(strchr(str, 0), "*");


### PR DESCRIPTION
- certain code paths were appending to the string without first clearing it.
- some prints were using spaces instead of tabs

Change-Id: I7a3d38289c8206682baf8942abf5a9950a56b449
Reviewed-on: https://go-review.googlesource.com/3511
Reviewed-by: Austin Clements austin@google.com
Reviewed-by: Dave Cheney dave@cheney.net
