### PR TITLE
cmd/gc: disable walkdiv

### DIFF
--- a/src/cmd/gc/walk.c
+++ b/src/cmd/gc/walk.c
@@ -3528,7 +3528,8 @@ walkdiv(Node **np, NodeList **init)
 	Magic m;
 
 	// TODO(minux)
-	if(thechar == '9')
+	// TODO(dfc)
+	if(thechar == '9' || thechar == '7')
 		return;
 
 	n = *np;


### PR DESCRIPTION
Walkdiv didn't work in 9g, and since 7g is based on 9g, it is likely that walkdiv doesn't work there either.

Update #108 #110 
