### PR TITLE
arm64, malloc: Support 64KB pages

### DIFF
--- a/src/runtime/arch1_arm64.go
+++ b/src/runtime/arch1_arm64.go
@@ -9,7 +9,7 @@ const (
 	_BigEndian        = 0
 	_CacheLineSize    = 32
 	_RuntimeGogoBytes = 64
-	_PhysPageSize     = 4096
+	_PhysPageSize     = 65536
 	_PCQuantum        = 4
 	_Int64Align       = 8
 	hugePageSize      = 0

--- a/src/runtime/malloc.go
+++ b/src/runtime/malloc.go
@@ -104,7 +104,7 @@ const (
 )
 
 const (
-	_PageShift = 13
+	_PageShift = 13 * (1 - goarch_arm64) + 16 * goarch_arm64
 	_PageSize  = 1 << _PageShift
 	_PageMask  = _PageSize - 1
 )
@@ -118,7 +118,7 @@ const (
 	// size classes.  NumSizeClasses is that number.  It's needed here
 	// because there are static arrays of this length; when msize runs its
 	// size choosing algorithm it double-checks that NumSizeClasses agrees.
-	_NumSizeClasses = 67
+	_NumSizeClasses = 67 * (1 - goarch_arm64) + 73 * goarch_arm64
 
 	// Tunable constants.
 	_MaxSmallSize = 32 << 10
@@ -132,7 +132,7 @@ const (
 	_HeapAllocChunk = 1 << 20                // Chunk size for heap growth
 
 	// Per-P, per order stack segment cache size.
-	_StackCacheSize = 32 * 1024
+	_StackCacheSize = 32 * 1024 * (1 - goarch_arm64) + _PageSize * goarch_arm64
 
 	// Number of orders that get caching.  Order 0 is FixedStack
 	// and each successive order is twice as large.


### PR DESCRIPTION
Hi,
This is my attempt to fix the issues I was having running go on 64KB pages on my Seattle board, #147 . As is evident from my patch, I am not a go programmer ;-). Please do tidy this up if it needs it. Also, if there is already a 64KB fix out there that I've missed, then please sling it my way and I would be happy to test it here.

Cheers,
Steve

On arm64 we can run with 64KB pages as well as 4KB pages.
Unfortunately, the memory allocator in go assumes pages are of size 4KB
and we run into problems such as:
    runtime: address space conflict: map(0x4000001000) = 0x3ff7e090000
    fatal error: runtime: address space conflict

This patch increases the _PageShift to 16 for arm64 and also beefs up
the _StackCacheSize to one page for arm64.

I have tested this patch on an AMD Seattle system running 64KB pages
and 4.0-rc5 kernel as well as an APM Mustang system running 4KB pages
and 3.19 kernel.

I don't know why this hasn't arisen in PowerPC, perhaps a lucky set
of addresses back from mmap? Perhaps this patch could be extended for
PowerPC too if need be?

Signed-off-by: Steve Capper steve.capper@linaro.org
